### PR TITLE
Short-circuit start-docker

### DIFF
--- a/start-docker.sh
+++ b/start-docker.sh
@@ -3,6 +3,14 @@
 # this script is a simplified version of:
 # /Applications/Docker/Docker Quickstart Terminal.app/Contents/Resources/Scripts/start.sh
 
+docker ps &> /dev/null
+DOCKER_RUNNING_CODE=$?
+
+if [ $DOCKER_RUNNING_CODE -eq 0 ]; then
+    echo "Docker already running."
+    return
+fi
+
 VM=default
 DOCKER_MACHINE=/usr/local/bin/docker-machine
 VBOXMANAGE=/Applications/VirtualBox.app/Contents/MacOS/VBoxManage


### PR DESCRIPTION
Now that docker for mac is out (!), it's possible that you no longer need docker-machine to run docker.

This just short-circuits start-docker.sh if there is already a docker daemon running, so `update.sh` and `run.sh` work out of the box on a machine that is already running docker. Doesn't do anything otherwise.